### PR TITLE
netdata: allow customizing netdata.conf, allow custom host domain

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -64,6 +64,7 @@ ansible_nas_email: me@example.com
 
 # Applications will have subdomain SSL certificates created if Traefik is enabled, e.g. ansible-nas.<your-domain>, nextcloud.<your-domain>
 ansible_nas_domain: example.com
+ansible_nas_domain_root: "{{ ansible_nas_domain }}"
 
 ###
 ### Samba

--- a/roles/netdata/defaults/main.yml
+++ b/roles/netdata/defaults/main.yml
@@ -2,9 +2,34 @@
 netdata_enabled: false
 netdata_available_externally: "false"
 
+# directories
+netdata_data_directory: "{{ docker_home }}/netdata"
+
+netdata_directories:
+  - "{{ netdata_data_directory }}"
+netdata_directories_custom: []
+
+netdata_template_files:
+  - src: netdata.conf.j2
+    dest: "{{ netdata_data_directory }}/etc/netdata.conf"
+netdata_template_files_custom: []
+
 # network
 netdata_hostname: "netdata"
 netdata_port: "19999"
 
 # specs
 netdata_memory: 1g
+netdata_volumes:
+  - "/proc:/host/proc:ro"
+  - "/sys:/host/sys:ro"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  - "{{ netdata_data_directory }}/etc/netdata.conf:/etc/netdata/netdata.conf:ro"
+  - "{{ netdata_data_directory }}/dbengine:/var/cache/netdata/dbengine:rw"
+netdata_volumes_custom: []
+
+# config - https://learn.netdata.cloud/docs/configure/common-changes
+netdata_config:
+  global:
+    - "page cache size = 32"                # MiB of RAM used to store metrics
+    - "dbengine multihost disk space = 128" # MiB of disk to store history

--- a/roles/netdata/tasks/main.yml
+++ b/roles/netdata/tasks/main.yml
@@ -4,19 +4,53 @@
     name: docker
   register: docker_group
 
+- name: Create netdata group
+  group:
+    name: netdata
+    gid: "201"
+    state: present
+  register: netdata_group
+
+- name: Create netdata user
+  user:
+    name: netdata
+    state: present
+    system: yes
+    create_home: no
+    group: netdata
+    uid: "201"
+    shell: /usr/sbin/nologin
+  register: netdata_user
+
+- name: Create Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+    owner: "netdata"
+    group: "netdata"
+  with_items: "{{ netdata_directories + netdata_directories_custom | sort }}"
+  when: netdata_user.state == "present" and netdata_group.state == "present"
+
+- name: Template Files
+  register: template_config
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    force: "{{ item.force | default(false) }}"
+    mode: "{{ item.mode | default('0600') }}"
+  with_items: "{{ netdata_template_files + netdata_template_files_custom | sort }}"
+
 - name: Netdata Docker Container
   docker_container:
     name: netdata
-    hostname: "{{ ansible_nas_hostname }}.{{ ansible_nas_domain }}"
+    hostname: "{{ ansible_nas_hostname }}.{{ ansible_nas_domain_root }}"
     image: netdata/netdata
     state: started
     pull: true
     ports:
       - "{{ netdata_port }}:19999"
-    volumes:
-      - "/proc:/host/proc:ro"
-      - "/sys:/host/sys:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    volumes: "{{ netdata_volumes + netdata_volumes_custom | sort }}"
     env:
       PGID: "{{ docker_group.gid }}"
     capabilities:
@@ -25,6 +59,7 @@
       - apparmor:unconfined
     restart_policy: unless-stopped
     memory: "{{ netdata_memory }}"
+    recreate: "{{ template_config is changed }}"
     labels:
       traefik.enable: "{{ netdata_available_externally }}"
       traefik.http.routers.netdata.rule: "Host(`{{ netdata_hostname }}.{{ ansible_nas_domain }}`)"

--- a/roles/netdata/templates/netdata.conf.j2
+++ b/roles/netdata/templates/netdata.conf.j2
@@ -1,0 +1,4 @@
+{% for key in netdata_config %}
+[{{ key }}]
+{# { netdata_config[[key][0]]|join("\n") } #}
+{% endfor %}


### PR DESCRIPTION
- use netdata.conf.j2 to template the netdata.conf file
- allow custom files to be templated
- mount netdata.conf file into docker container
- mount dbengine volume in container to allow history retention
  when rebuiliding container
- allow custom volumes to be mounted in the container
- add `ansible_nas_domain_root` variable used as netdata hostname
  when you have multiple nas servers this allows you to properly name
  the server in netdata.
  example:
  - `ansible_nas_hostname`: nas
  - `ansible_nas_domain`: nas.domain.tld
  - `ansible_nas_domain_root`: domain.tld

  original netdata hostname: nas.nas.domain.tld
  new netdata hostname: nas.domain.tld

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:



**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
